### PR TITLE
Switch to newly-released rust-stable as default package

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name        'garethr-rustlang'
-version     '0.0.1'
+version     '0.0.2'
 source      'git://github.com/garethr/garethr-rustlang.git'
 author      'Gareth Rushgrove'
 summary     'Module for installing rust from a ppa'

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ The module includes a single class:
 
     include 'rustlang'
 
-By default this sets up the PPA and installs the rust-0.8 package.
+By default this sets up the PPA and installs the rust-stable package.
 See the code for ways to get rust-nightly or other versions.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,7 @@
 # === Parameters
 # [*package_name*]
 #   Which package you want. Valid values are rust-0.x
-#   and rust-nightly. Defaults to rust-0.8.
+#   and rust-nightly. Defaults to rust-stable.
 #
 # [*ensure*]
 #   Whether to install or remove the package. Can be either

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@
 #   absent or present. Defaults to present.
 #
 class rustlang(
-  $package_name = 'rust-0.8',
+  $package_name = 'rust-stable',
   $ensure = 'present',
 ) {
   include apt

--- a/spec/classes/rustlang_spec.rb
+++ b/spec/classes/rustlang_spec.rb
@@ -10,7 +10,7 @@ describe 'rustlang', :type => :class do
 
   context 'with no parameters' do
     it { should include_class('apt') }
-    it { should contain_package('rustlang').with_name('rust-0.8').with_ensure('present') }
+    it { should contain_package('rustlang').with_name('rust-stable').with_ensure('present') }
     it { should contain_apt__ppa('ppa:hansjorg/rust') }
   end
 


### PR DESCRIPTION
The rust project has recently reached its first stable release (v1.0.0) and hansjorg has published it as the rust-stable package in his ppa.  This pull request installs that package by default.
